### PR TITLE
feat: add conversation tracking for group chats

### DIFF
--- a/agent_comm/core/message_handler.py
+++ b/agent_comm/core/message_handler.py
@@ -226,20 +226,23 @@ class MessageHandler:
         """
         try:
             pending_calls = self.state_manager.get_pending_calls()
-            
+
             if not pending_calls:
                 return True, "No pending tool calls."
-            
+
             # Format pending calls
             pending_list = []
-            for agent_id, call_info in pending_calls.items():
+            for call_id, call_info in pending_calls.items():
+                participants = ", ".join(call_info.get("participants", []))
                 message = call_info.get("message", "No message")
                 timestamp = call_info.get("timestamp", "unknown")
-                
-                pending_list.append(f"• {agent_id}: {message[:50]}{'...' if len(message) > 50 else ''} ({timestamp})")
-            
+
+                pending_list.append(
+                    f"• {call_id} [{participants}]: {message[:50]}{'...' if len(message) > 50 else ''} ({timestamp})"
+                )
+
             pending_text = "\n".join(pending_list)
-            
+
             return True, f"Pending tool calls ({len(pending_calls)}):\n\n{pending_text}"
             
         except Exception as e:

--- a/agent_comm/engine.py
+++ b/agent_comm/engine.py
@@ -59,7 +59,7 @@ def handle_send_message(from_agent: str, message: str) -> str:
         
         # Add to pending calls (waiting for user to route)
         state_manager = StateManager()
-        state_manager.add_pending_call(from_agent_id, message)
+        call_id = state_manager.add_pending_call([from_agent_id], message)
         
         # Show UI to let user choose target
         target_agent = show_controller_ui()
@@ -72,12 +72,12 @@ def handle_send_message(from_agent: str, message: str) -> str:
             )
             
             # Remove from pending calls
-            state_manager.remove_pending_call(from_agent_id)
+            state_manager.remove_pending_call(call_id)
             
             return result
         else:
             # Remove from pending calls if cancelled
-            state_manager.remove_pending_call(from_agent_id)
+            state_manager.remove_pending_call(call_id)
             return "Message sending cancelled by user"
     
     except Exception as e:
@@ -110,8 +110,9 @@ def handle_interactive_communication(agent_id: str = None, message: str = None) 
         state_manager = StateManager()
         
         # Add to pending calls if agent provided
+        call_id = None
         if agent_id:
-            state_manager.add_pending_call(agent_id, message)
+            call_id = state_manager.add_pending_call([agent_id], message)
         
         # Show UI
         target_agent = show_controller_ui()
@@ -127,13 +128,14 @@ def handle_interactive_communication(agent_id: str = None, message: str = None) 
             )
             
             # Remove from pending calls
-            state_manager.remove_pending_call(agent_id_parsed)
+            if call_id:
+                state_manager.remove_pending_call(call_id)
             
             return result
         else:
             # Just show UI for monitoring
-            if agent_id:
-                state_manager.remove_pending_call(agent_id)
+            if call_id:
+                state_manager.remove_pending_call(call_id)
             return "Agent Communication UI closed"
     
     except Exception as e:


### PR DESCRIPTION
## Summary
- track conversation IDs and participant lists in FlowManager
- display group conversations and broadcast or target messages in controller UI
- expand pending call handling for multi-agent sessions

## Testing
- `python -m py_compile agent_comm/core/state_manager.py agent_comm/core/message_handler.py agent_comm/engine.py agent_comm/core/flow_manager.py agent_comm/ui/controller_ui.py`

------
https://chatgpt.com/codex/tasks/task_e_6894265e9470832cb6cd43cdb33cf97b