### PR TITLE
Bind group chat agents to file-scoped editors

### DIFF
--- a/agent_comm/core/file_scoped_editor.py
+++ b/agent_comm/core/file_scoped_editor.py
@@ -1,0 +1,34 @@
+import logging
+from pathlib import Path
+from typing import Callable
+
+
+class FileScopedEditor:
+    """Provides scoped read/modify operations for a single file.
+
+    Each editor instance is bound to one file path and logs all read and
+    write operations performed by its associated agent.
+    """
+
+    def __init__(self, file_path: str, agent_id: str):
+        self.file_path = Path(file_path).resolve()
+        self.agent_id = agent_id
+        self.logger = logging.getLogger("agent_comm.FileScopedEditor")
+
+    def read(self) -> str:
+        """Return the entire content of the scoped file."""
+        content = self.file_path.read_text(encoding="utf-8")
+        self.logger.info("[%s] read from %s", self.agent_id, self.file_path)
+        return content
+
+    def modify(self, transform: Callable[[str], str]) -> None:
+        """Apply ``transform`` to the file content and persist the result.
+
+        Args:
+            transform: Callable receiving current file content and returning
+                modified content.
+        """
+        original = self.read()
+        updated = transform(original)
+        self.file_path.write_text(updated, encoding="utf-8")
+        self.logger.info("[%s] wrote to %s", self.agent_id, self.file_path)


### PR DESCRIPTION
## Summary
- add `FileScopedEditor` to wrap read/modify operations for a single file and log all accesses
- track file-scoped editors in `StateManager`
- bind group chat agents to their file editors in `agent_group_chat_tool`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68942a86fc60832c9959b30bdfddf0b1